### PR TITLE
Add an optional TTL_IN_DAYS parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ curl -X POST https://{subdomain}.{domain}/create/ \
 -d '{"long_url": "https://google.com"}'
 ```
 
+Optionnaly, you can change the default TTL value (7 days), by using the `ttl_in_days` attribute in body request:
+```bash
+curl -X POST https://{subdomain}.{domain}/create/ \
+--header "Content-Type: application/json" \
+-d '{"long_url": "https://google.com", "ttl_in_days": 365}'
+```
+
 ##### Response sample
 
 ```json

--- a/backend/backend.yml
+++ b/backend/backend.yml
@@ -172,6 +172,9 @@ Resources:
           Value: !Ref pProjectName
         - Key: Product
           Value: !Ref pProductName
+      TimeToLiveSpecification:
+        AttributeName: ttl
+        Enabled: true
 
   ShortenerLambdaLogGroup:
     Type: AWS::Logs::LogGroup


### PR DESCRIPTION
Hello Zoph!

I don't know if you are interested or not, but I did a minor update in the API handler to accept and optional attribute `ttl_in_days`. 

It lets the user selects a TTL different from the default `7`.

If not set, 7 days is considered (as today).
If set to negative value, it will set a TTL to 100 years (even if the EPOCH may have issue in 2038).

I also updated the `README.md`, but for the cURL command only.

I may try to update the front as well (one day), and the Makefile (but I'm not very comfortable with it yet), to have this options available whatever the creation process.