### PR TITLE
Adding "human readable" option

### DIFF
--- a/backend/backend.yml
+++ b/backend/backend.yml
@@ -58,6 +58,8 @@ Resources:
             RestApiId:
               Ref: APIGateway
       MemorySize: 256
+      Architectures:
+        - arm64
       Timeout: 300
       Environment:
         Variables:

--- a/shortener/handlers.py
+++ b/shortener/handlers.py
@@ -8,6 +8,7 @@ from time import strftime, time
 from urllib import parse
 import logging
 import validators
+import math
 
 # Logging configuration
 root = logging.getLogger()
@@ -69,16 +70,31 @@ def check_id(short_id):
     response = ddb.get_item(Key={"short_id": short_id})
     if "Item" in response:
         print("short_id already exists in Table, generating a new one")
-        return generate_id()
+        return False
     else:
         print("newly generate_id is not used, going forward:", short_id)
-        return short_id
+        return True
 
-def generate_id():
-    short_id = "".join(
-        choice(string_format) for x in range(randint(min_char, max_char))
-    )
-    return check_id(short_id)
+def generate_id( human_readble = False ):
+
+    vowels = ['a', 'e', 'i', 'o', 'u', 'y']
+    consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x',  'z']
+    syllabs = math.ceil(randint(min_char, max_char) / 2)
+    
+    
+    unique = False
+    while not unique:
+        if not human_readble:
+            short_id = "".join(
+                choice(string_format) for x in range(randint(min_char, max_char))
+            )
+        else:
+            short_id = "".join(
+                (choice(consonants)+choice(vowels)) for x in range(syllabs)      
+            )
+        unique = check_id(short_id)
+
+    return short_id    
 
 
 def main(event, context):
@@ -107,8 +123,6 @@ def main(event, context):
 
 def create(event, context):
     analytics = {}
-    short_id = generate_id()
-    short_url = "https://" + sub_domain + "." + domain + "/" + short_id
 
     # Handle empty long_url
     if not json.loads(event.get("body")).get("long_url"):
@@ -137,6 +151,14 @@ def create(event, context):
                 },
                 "body": json.dumps({"message": "Malformed URL"}),
             }
+
+    if not json.loads(event.get("body")).get("human_readable"):
+        short_id = generate_id(False)
+    else:
+        short_id = generate_id(True)
+    short_url = "https://" + sub_domain + "." + domain + "/" + short_id
+
+
 
     # Try to read the ttl_in_days value
     try:
@@ -169,7 +191,8 @@ def create(event, context):
                 "long_url": long_url,
                 "analytics": analytics,
                 "hits": int(0),
-            }
+            },
+
         )
 
         body = {
@@ -190,7 +213,10 @@ def create(event, context):
             "body": json.dumps(body),
         }
     except ClientError as e:
-        logging.error("Error while writing new short_url to table: %s", e)
+        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
+            print('Item already exists')
+        else:
+            logging.error("Error while writing new short_url to table: %s", e)
 
     return answer
 

--- a/shortener/handlers.py
+++ b/shortener/handlers.py
@@ -78,7 +78,7 @@ def check_id(short_id):
 def generate_id( human_readble = False ):
 
     vowels = ['a', 'e', 'i', 'o', 'u', 'y']
-    consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'q', 'r', 's', 't', 'v', 'w', 'x',  'z']
+    consonants = ['b', 'c', 'd', 'f', 'g', 'h', 'j', 'k', 'l', 'm', 'n', 'p', 'r', 's', 't', 'v', 'w', 'x',  'z']
     syllabs = math.ceil(randint(min_char, max_char) / 2)
     
     

--- a/shortener/handlers.py
+++ b/shortener/handlers.py
@@ -213,10 +213,7 @@ def create(event, context):
             "body": json.dumps(body),
         }
     except ClientError as e:
-        if e.response['Error']['Code'] == 'ConditionalCheckFailedException':
-            print('Item already exists')
-        else:
-            logging.error("Error while writing new short_url to table: %s", e)
+        logging.error("Error while writing new short_url to table: %s", e)
 
     return answer
 

--- a/shortener/handlers.py
+++ b/shortener/handlers.py
@@ -191,8 +191,7 @@ def create(event, context):
                 "long_url": long_url,
                 "analytics": analytics,
                 "hits": int(0),
-            },
-
+            }
         )
 
         body = {


### PR DESCRIPTION
Hi @z0ph!

Another PR, to add a feature and an "improvement": feel free to refuse it, I would understand ^^

## **Feature**

Added the `human_readable`attribute in POST body, defaulted to `false` for backward compatibility. 
If set to `true`, the generated ID will a suite of consonant, vowel, consonant, vowel, etc... (length between the range +1 if not even)

For instance: `loka`, `gyro`, `mota`, `vupi`, `jusa`, `bumy`...


## "Improvement"
_Sorry, I should have done that in a separate PR_ 

I switched the function from `x86` to `arm64` architecture. Performance are good, less energy consumption, cheaper (if you exceed the free tier).


Once again, these are changed I've made to meet my own need, so, do not hesitate to refuse the PR if it is not aligned with the target you had for this tool!

Cheers
